### PR TITLE
BUGFIX: take the number of waves into account when shooting

### DIFF
--- a/kotlininvaders/Invader.kt
+++ b/kotlininvaders/Invader.kt
@@ -109,7 +109,7 @@ class Invader(context: Context, row: Int, column: Int, screenX: Int, screenY: In
 
             // The fewer invaders the more each invader shoots
             // The higher the wave the more the invader shoots
-            randomNumber = generator.nextInt(100 * numberOfInvaders) / waves
+            randomNumber = generator.nextInt((100 * numberOfInvaders) / waves)
             if (randomNumber == 0) {
                 return true
             }


### PR DESCRIPTION
Before the fix, the wave number was outside of the random number generation call and would never change the odds of whether to fire or not.